### PR TITLE
fix: automatically discover meter ID if not provided in NewClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ if err != nil {
     log.Fatal(err)
 }
 
+// auto-discover meter ID
+client.DiscoverMeterID()  
+
 // Query meter values
 values, err := client.GetMeterValues()
 ```

--- a/client.go
+++ b/client.go
@@ -79,13 +79,6 @@ func NewClient(uri, user, password, meterID string) (*Client, error) {
 		meterID:       meterID,
 	}
 
-	if meterID == "" {
-		err := c.DiscoverMeterID()
-		if err != nil {
-			return nil, fmt.Errorf("failed to discover meter ID: %w", err)
-		}
-	}
-
 	return c, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -78,7 +78,7 @@ func NewClient(uri, user, password, meterID string) (*Client, error) {
 		uri:           uri,
 		meterID:       meterID,
 	}
-	
+
 	if meterID == "" {
 		err := c.DiscoverMeterID()
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -78,6 +78,14 @@ func NewClient(uri, user, password, meterID string) (*Client, error) {
 		uri:           uri,
 		meterID:       meterID,
 	}
+	
+	if meterID == "" {
+		meterID, err := c.DiscoverMeterID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover meter ID: %w", err)
+		}
+		c.meterID = meterID
+	}
 
 	return c, nil
 }

--- a/client.go
+++ b/client.go
@@ -80,11 +80,10 @@ func NewClient(uri, user, password, meterID string) (*Client, error) {
 	}
 	
 	if meterID == "" {
-		meterID, err := c.DiscoverMeterID()
+		err := c.DiscoverMeterID()
 		if err != nil {
 			return nil, fmt.Errorf("failed to discover meter ID: %w", err)
 		}
-		c.meterID = meterID
 	}
 
 	return c, nil


### PR DESCRIPTION
DiscoverMeterID wurde nicht ausgeführt, wenn keine MeterID in der NewClient übergeben wurde oder NewClientDiscover aufgerufen wurde.

